### PR TITLE
Fixes catkin build error

### DIFF
--- a/robot_navigation/CMakeLists.txt
+++ b/robot_navigation/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robot_navigation)
-
 find_package(catkin REQUIRED)
-
-catkin_package()
+catkin_metapackage()


### PR DESCRIPTION
I believe there may be an issue with the robot_navigation CMakeLists.txt that is causing the build to fail for catkin in ROS Kinetic.  Firstly, the last package tag in CMakeLists.txt should be `catkin_metapackage()` Secondly, there are empty lines in the file that cause the build system to give this error:

> CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkin_workspace.cmake:95 (message):
  This workspace contains non-catkin packages in it, and catkin cannot build
  a non-homogeneous workspace without isolation.  Try the
  'catkin_make_isolated' command instead.

This fixes the aforementioned issues.