### PR TITLE
Fix costmap queue losing enqueued cells

### DIFF
--- a/costmap_queue/src/costmap_queue.cpp
+++ b/costmap_queue/src/costmap_queue.cpp
@@ -76,6 +76,7 @@ CellData CostmapQueue::getNextCell()
 {
   // get the highest priority cell and pop it off the priority queue
   CellData current_cell = front();
+  pop();
 
   unsigned int mx = current_cell.x_;
   unsigned int my = current_cell.y_;
@@ -92,8 +93,6 @@ CellData CostmapQueue::getNextCell()
   if (my < costmap_.getHeight() - 1)
     enqueueCell(mx, my + 1, sx, sy);
 
-  // pop once we have our cell info
-  pop();
   return current_cell;
 }
 


### PR DESCRIPTION
In the `CostmapQueue::getNextCell` method, the head of the queue is referenced, adjacent cells are enqueued and then the head of the queue is popped. However, enqueuing the adjacent cells can change the head of the queue, resulting in a newly added cell getting popped instead of the cell that was just processed.

When this happens, the newly added cell will never get pulled from the queue and it's adjacent cells may never get expanded.

This will happen whenever a newly added cell has a lower cost than the head of the queue. Normally, this would never happen with a CostmapQueue, but can happen in MapGridQueue as cells are expanded behind obstacles as seen in ros-planning/navigation2/issues/451