### PR TITLE
Call reset on new plan, not new goal

### DIFF
--- a/dwb_local_planner/src/dwb_local_planner.cpp
+++ b/dwb_local_planner/src/dwb_local_planner.cpp
@@ -161,18 +161,18 @@ void DWBLocalPlanner::setGoalPose(const nav_2d_msgs::Pose2DStamped& goal_pose)
 {
   ROS_INFO_NAMED("DWBLocalPlanner", "New Goal Received.");
   goal_pose_ = goal_pose;
-  traj_generator_->reset();
-  goal_checker_->reset();
-  for (TrajectoryCritic::Ptr critic : critics_)
-  {
-    critic->reset();
-  }
 }
 
 void DWBLocalPlanner::setPlan(const nav_2d_msgs::Path2D& path)
 {
   pub_.publishGlobalPlan(path);
   global_plan_ = path;
+  traj_generator_->reset();
+  goal_checker_->reset();
+  for (TrajectoryCritic::Ptr critic : critics_)
+  {
+    critic->reset();
+  }
 }
 
 nav_2d_msgs::Twist2DStamped DWBLocalPlanner::computeVelocityCommands(const nav_2d_msgs::Pose2DStamped& pose,


### PR DESCRIPTION
The documentation on `reset()` says:

> called at the beginning of every new navigation, i.e. when we get a
> new global plan

The `reset()` functions were called in `setGoalPose()`, i.e. when the user gives a new goal. However, when the local planner fails and the global planner replans, `setGoalPose()` is not called, but `setPlan()` is. This PR makes sure that `reset()` is also called in this case.