### PR TITLE
Fix build with catkin_make

### DIFF
--- a/costmap_queue/CMakeLists.txt
+++ b/costmap_queue/CMakeLists.txt
@@ -31,7 +31,7 @@ if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(utest test/utest.cpp)
   target_link_libraries(utest ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif (CATKIN_ENABLE_TESTING)

--- a/costmap_queue/CMakeLists.txt
+++ b/costmap_queue/CMakeLists.txt
@@ -28,8 +28,8 @@ if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(mbq_test test/mbq_test.cpp)
   target_link_libraries(mbq_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(utest test/utest.cpp)
-  target_link_libraries(utest ${PROJECT_NAME} ${catkin_LIBRARIES})
+  catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
+  target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   find_package(roslint REQUIRED)
   roslint_cpp()

--- a/dlux_global_planner/CMakeLists.txt
+++ b/dlux_global_planner/CMakeLists.txt
@@ -35,9 +35,10 @@ add_library(dgp src/dlux_global_planner.cpp src/cost_interpreter.cpp)
 add_dependencies(dgp ${catkin_EXPORTED_TARGETS})
 target_link_libraries(dgp ${catkin_LIBRARIES})
 
-add_executable(planner_node src/planner_node.cpp)
-add_dependencies(planner_node ${catkin_EXPORTED_TARGETS})
-target_link_libraries(planner_node dgp ${catkin_LIBRARIES})
+add_executable(${PROJECT_NAME}_planner_node src/planner_node.cpp)
+add_dependencies(${PROJECT_NAME}_planner_node ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}_planner_node dgp ${catkin_LIBRARIES})
+set_target_properties(${PROJECT_NAME}_planner_node PROPERTIES OUTPUT_NAME planner_node PREFIX "")
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
@@ -51,7 +52,7 @@ if (CATKIN_ENABLE_TESTING)
   target_link_libraries(kernel_test dgp)
 endif()
 
-install(TARGETS planner_node
+install(TARGETS ${PROJECT_NAME}_planner_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(TARGETS dgp

--- a/dlux_global_planner/CMakeLists.txt
+++ b/dlux_global_planner/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(planner_node dgp ${catkin_LIBRARIES})
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 

--- a/dlux_global_planner/package.xml
+++ b/dlux_global_planner/package.xml
@@ -19,6 +19,8 @@
   <depend>roscpp</depend>
   <depend>visualization_msgs</depend>
   <test_depend>roslint</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
   <export>
     <nav_core2 plugin="${prefix}/nav_core2_plugins.xml"/>
   </export>

--- a/dlux_plugins/CMakeLists.txt
+++ b/dlux_plugins/CMakeLists.txt
@@ -21,9 +21,8 @@ include_directories(
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
-  find_package(global_planner_tests)
+  find_package(global_planner_tests REQUIRED)
   include_directories(include ${global_planner_tests_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS})
-  link_directories(${GTEST_LIBRARY_DIRS})
 
   add_rostest_gtest(planner_test test/planner_test.launch test/planner_test.cpp)
   target_link_libraries(planner_test ${global_planner_tests_LIBRARIES} ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
@@ -35,7 +34,7 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(got test/global_oscillation_test.launch test/global_oscillation_test.cpp)
   target_link_libraries(got ${global_planner_tests_LIBRARIES} ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif()

--- a/dwb_critics/CMakeLists.txt
+++ b/dwb_critics/CMakeLists.txt
@@ -46,7 +46,7 @@ add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif()

--- a/dwb_local_planner/CMakeLists.txt
+++ b/dwb_local_planner/CMakeLists.txt
@@ -45,9 +45,10 @@ add_dependencies(debug_dwb_local_planner ${catkin_EXPORTED_TARGETS})
 add_library(trajectory_utils src/trajectory_utils.cpp)
 target_link_libraries(trajectory_utils ${catkin_LIBRARIES})
 
-add_executable(planner_node src/planner_node.cpp)
-target_link_libraries(planner_node ${catkin_LIBRARIES} debug_dwb_local_planner)
-add_dependencies(planner_node ${catkin_EXPORTED_TARGETS})
+add_executable(${PROJECT_NAME}_planner_node src/planner_node.cpp)
+target_link_libraries(${PROJECT_NAME}_planner_node ${catkin_LIBRARIES} debug_dwb_local_planner)
+add_dependencies(${PROJECT_NAME}_planner_node ${catkin_EXPORTED_TARGETS})
+set_target_properties(${PROJECT_NAME}_planner_node PROPERTIES OUTPUT_NAME planner_node PREFIX "")
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
@@ -59,7 +60,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(utils_test trajectory_utils)
 endif()
 
-install(TARGETS planner_node
+install(TARGETS ${PROJECT_NAME}_planner_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(TARGETS dwb_local_planner debug_dwb_local_planner trajectory_utils

--- a/dwb_local_planner/CMakeLists.txt
+++ b/dwb_local_planner/CMakeLists.txt
@@ -51,7 +51,7 @@ add_dependencies(planner_node ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 

--- a/dwb_local_planner/package.xml
+++ b/dwb_local_planner/package.xml
@@ -24,8 +24,9 @@
   <depend>tf</depend>
   <depend>visualization_msgs</depend>
   <test_depend>roslint</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
   <export>
     <nav_core2 plugin="${prefix}/plugins.xml"/>
   </export>
-
 </package>

--- a/dwb_plugins/CMakeLists.txt
+++ b/dwb_plugins/CMakeLists.txt
@@ -43,7 +43,7 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(twist_gen_test test/twist_gen.launch test/twist_gen.cpp)
   target_link_libraries(twist_gen_test standard_traj_generator ${GTEST_LIBRARIES})
 
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif (CATKIN_ENABLE_TESTING)

--- a/dwb_plugins/package.xml
+++ b/dwb_plugins/package.xml
@@ -21,6 +21,8 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
 
   <export>
     <dwb_local_planner plugin="${prefix}/plugins.xml"/>

--- a/global_planner_tests/CMakeLists.txt
+++ b/global_planner_tests/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(
 )
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif()

--- a/locomotor/CMakeLists.txt
+++ b/locomotor/CMakeLists.txt
@@ -48,7 +48,7 @@ include_directories(
 )
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif()

--- a/locomove_base/CMakeLists.txt
+++ b/locomove_base/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(
 )
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 endif()

--- a/nav_2d_utils/CMakeLists.txt
+++ b/nav_2d_utils/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(polygons ${catkin_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 

--- a/nav_2d_utils/package.xml
+++ b/nav_2d_utils/package.xml
@@ -21,5 +21,5 @@
   <depend>xmlrpcpp</depend>
   <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
-
+  <test_depend>rosunit</test_depend>
 </package>

--- a/nav_core2/CMakeLists.txt
+++ b/nav_core2/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(
 )
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 

--- a/nav_core2/package.xml
+++ b/nav_core2/package.xml
@@ -13,4 +13,5 @@
   <depend>nav_grid</depend>
   <depend>tf</depend>
   <test_depend>roslint</test_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/nav_core_adapter/CMakeLists.txt
+++ b/nav_core_adapter/CMakeLists.txt
@@ -55,7 +55,7 @@ include_directories(
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 

--- a/nav_grid/CMakeLists.txt
+++ b/nav_grid/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 2.8.3)
 project(nav_grid)
 set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
 
-find_package(catkin)
+find_package(catkin REQUIRED)
 
 catkin_package(
     INCLUDE_DIRS include
 )
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   include_directories(include ${catkin_INCLUDE_DIRS})
   roslint_cpp()
   roslint_add_test()

--- a/nav_grid/CMakeLists.txt
+++ b/nav_grid/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CATKIN_ENABLE_TESTING)
   include_directories(include ${catkin_INCLUDE_DIRS})
   roslint_cpp()
   roslint_add_test()
-  catkin_add_gtest(utest test/utest.cpp)
+  catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
 endif (CATKIN_ENABLE_TESTING)
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/nav_grid/package.xml
+++ b/nav_grid/package.xml
@@ -9,4 +9,5 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
   <test_depend>roslint</test_depend>
+  <test_depend>rosunit</test_depend>
 </package>

--- a/nav_grid_iterators/CMakeLists.txt
+++ b/nav_grid_iterators/CMakeLists.txt
@@ -44,8 +44,8 @@ if (CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(line_tests test/line_tests.cpp)
   target_link_libraries(line_tests nav_grid_iterators)
-  catkin_add_gtest(utest test/utest.cpp)
-  target_link_libraries(utest nav_grid_iterators)
+  catkin_add_gtest(${PROJECT_NAME}_utest test/utest.cpp)
+  target_link_libraries(${PROJECT_NAME}_utest nav_grid_iterators)
 endif (CATKIN_ENABLE_TESTING)
 
 install(TARGETS nav_grid_iterators

--- a/nav_grid_iterators/CMakeLists.txt
+++ b/nav_grid_iterators/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(
 )
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(roslint)
+  find_package(roslint REQUIRED)
   roslint_cpp()
   roslint_add_test()
 

--- a/nav_grid_iterators/package.xml
+++ b/nav_grid_iterators/package.xml
@@ -17,5 +17,5 @@
   <depend>nav_msgs</depend>
   <depend>roscpp</depend>
   <test_depend>roslint</test_depend>
-
+  <test_depend>rosunit</test_depend>
 </package>

--- a/nav_grid_pub_sub/CMakeLists.txt
+++ b/nav_grid_pub_sub/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(nav_grid_pub_sub ${catkin_LIBRARIES})
 add_dependencies(nav_grid_pub_sub ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)
-    find_package(roslint)
+    find_package(roslint REQUIRED)
     roslint_cpp()
     roslint_add_test()
 endif()


### PR DESCRIPTION
Building with catkin_make fails without this PR because the targets "utest" and "planner_node" are multiply defined. Building with catkin-tools or catkin_make_isolated doesn't trigger this bug, because these build tools build each CMake project separately (unlike catkin_make, which includes all CMakeLists as subprojects, so all targets need to be unique).

The following errors were thrown by catkin_make:

```
CMake Error at /opt/ros/kinetic/share/catkin/cmake/test/gtest.cmake:169 (add_executable):
  add_executable cannot create target "utest" because another target with the
  same name already exists.  The existing target is an executable created in
  source directory
  "/home/martin/ros/kinetic/robot_navigation/src/robot_navigation/nav_grid".
  See documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/test/gtest.cmake:79 (_catkin_add_executable_with_google_test)
  /opt/ros/kinetic/share/catkin/cmake/test/gtest.cmake:28 (_catkin_add_google_test)
  robot_navigation/costmap_queue/CMakeLists.txt:31 (catkin_add_gtest)

CMake Error at robot_navigation/costmap_queue/CMakeLists.txt:32 (target_link_libraries):
  Attempt to add link library "costmap_queue" to target "utest" which is not
  built in this directory.
```