### PR TITLE
Fix buildfarm tests again (increase test timeout)

### DIFF
--- a/dlux_plugins/test/planner_test.launch
+++ b/dlux_plugins/test/planner_test.launch
@@ -1,5 +1,5 @@
 <launch>
   <!-- Planner Test contains 6 configurations, each of which can take over a minute on a shiny developer laptop. -->
-  <!-- Conservatively, we limit each configuration to 3 minutes, allowing for the slowness of buildfarms, etc.   -->
-  <test test-name="planner_test" pkg="dlux_plugins" type="planner_test" time-limit="1080"/>
+  <!-- Conservatively, we limit each configuration to 10 minutes, allowing for the slowness of buildfarms, etc.   -->
+  <test test-name="planner_test" pkg="dlux_plugins" type="planner_test" time-limit="3600"/>
 </launch>


### PR DESCRIPTION
The current timeout of 1080 s (18 minutes) is too low for completing the tests. On my laptop, the total required time is 1222 s (20 min 22 s). On the buildfarm, it's also over 18 minutes.

These are the timings on my four-year-old development laptop (Intel(R) Core(TM) i7-4710MQ CPU @ 2.50GHz, 8 GB RAM):

| Test             | Duration |
|:-----------------|---------:|
| AStarVon         |    302 s |
| AStarGrid        |    297 s |
| AStarGradient    |    328 s |
| DijkstraVon      |     89 s |
| DijkstraGrid     |     92 s |
| DijkstraGradient |    114 s |

