### PR TITLE
get the proper exception code

### DIFF
--- a/nav_core2/include/nav_core2/exceptions.h
+++ b/nav_core2/include/nav_core2/exceptions.h
@@ -101,7 +101,8 @@ inline std::string poseToString(const nav_2d_msgs::Pose2DStamped& pose)
 class CostmapException: public std::runtime_error
 {
 public:
-  explicit CostmapException(const std::string& description, int result_code = COSTMAPEXCEPTION) : std::runtime_error(description), result_code_(result_code) {}
+  explicit CostmapException(const std::string& description, int result_code = COSTMAPEXCEPTION) :
+    std::runtime_error(description), result_code_(result_code) {}
   using Ptr = std::shared_ptr<CostmapException>;
   virtual int getResultCode() const { return result_code_; }
 
@@ -116,7 +117,8 @@ protected:
 class CostmapSafetyException: public CostmapException
 {
 public:
-  explicit CostmapSafetyException(const std::string& description, int result_code = COSTMAPSAFETYEXCEPTION) : CostmapException(description, result_code) {}
+  explicit CostmapSafetyException(const std::string& description, int result_code = COSTMAPSAFETYEXCEPTION) :
+    CostmapException(description, result_code) {}
   int getResultCode() const override { return result_code_; }
 };
 
@@ -129,7 +131,8 @@ public:
 class CostmapDataLagException: public CostmapSafetyException
 {
 public:
-  explicit CostmapDataLagException(const std::string& description, int result_code = COSTMAPDATALAGEXCEPTION) : CostmapSafetyException(description, result_code) {}
+  explicit CostmapDataLagException(const std::string& description, int result_code = COSTMAPDATALAGEXCEPTION) :
+    CostmapSafetyException(description, result_code) {}
   int getResultCode() const override { return result_code_; }
 };
 
@@ -140,7 +143,8 @@ public:
 class PlannerException: public std::runtime_error
 {
 public:
-  explicit PlannerException(const std::string& description, int result_code = PLANNEREXCEPTION) : std::runtime_error(description), result_code_(result_code) {}
+  explicit PlannerException(const std::string& description, int result_code = PLANNEREXCEPTION) :
+    std::runtime_error(description), result_code_(result_code) {}
   using Ptr = std::shared_ptr<PlannerException>;
   virtual int getResultCode() const { return result_code_; }
 
@@ -156,8 +160,9 @@ protected:
 class GlobalPlannerException: public PlannerException
 {
 public:
-  explicit GlobalPlannerException(const std::string& description, int result_code = GLOBALPLANNEREXCEPTION) : PlannerException(description, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  explicit GlobalPlannerException(const std::string& description, int result_code = GLOBALPLANNEREXCEPTION) :
+    PlannerException(description, result_code) {}
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -167,8 +172,9 @@ public:
 class LocalPlannerException: public PlannerException
 {
 public:
-  explicit LocalPlannerException(const std::string& description, int result_code = LOCALPLANNEREXCEPTION) : PlannerException(description, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  explicit LocalPlannerException(const std::string& description, int result_code = LOCALPLANNEREXCEPTION) :
+    PlannerException(description, result_code) {}
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -178,8 +184,9 @@ public:
 class PlannerTFException: public PlannerException
 {
 public:
-  explicit PlannerTFException(const std::string& description, int result_code = PLANNERTFEXCEPTION) : PlannerException(description, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  explicit PlannerTFException(const std::string& description, int result_code = PLANNERTFEXCEPTION) :
+    PlannerException(description, result_code) {}
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -189,10 +196,12 @@ public:
 class InvalidStartPoseException: public GlobalPlannerException
 {
 public:
-  explicit InvalidStartPoseException(const std::string& description, int result_code = INVALIDSTARTPOSEEXCEPTION) : GlobalPlannerException(description, result_code) {}
-  InvalidStartPoseException(const nav_2d_msgs::Pose2DStamped& pose, const std::string& problem, int result_code = INVALIDSTARTPOSEEXCEPTION) :
+  explicit InvalidStartPoseException(const std::string& description, int result_code = INVALIDSTARTPOSEEXCEPTION) :
+    GlobalPlannerException(description, result_code) {}
+  InvalidStartPoseException(const nav_2d_msgs::Pose2DStamped& pose,
+                            const std::string& problem, int result_code = INVALIDSTARTPOSEEXCEPTION) :
     GlobalPlannerException("The starting pose " + poseToString(pose) + " is " + problem, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -202,10 +211,11 @@ public:
 class StartBoundsException: public InvalidStartPoseException
 {
 public:
-  explicit StartBoundsException(const std::string& description, int result_code = STARTBOUNDSEXCEPTION) : InvalidStartPoseException(description, result_code) {}
+  explicit StartBoundsException(const std::string& description, int result_code = STARTBOUNDSEXCEPTION) :
+    InvalidStartPoseException(description, result_code) {}
   explicit StartBoundsException(const nav_2d_msgs::Pose2DStamped& pose, int result_code = STARTBOUNDSEXCEPTION) :
     InvalidStartPoseException(pose, "out of bounds", result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -215,10 +225,11 @@ public:
 class OccupiedStartException: public InvalidStartPoseException
 {
 public:
-  explicit OccupiedStartException(const std::string& description, int result_code = OCCUPIEDSTARTEXCEPTION) : InvalidStartPoseException(description, result_code) {}
+  explicit OccupiedStartException(const std::string& description, int result_code = OCCUPIEDSTARTEXCEPTION) :
+    InvalidStartPoseException(description, result_code) {}
   explicit OccupiedStartException(const nav_2d_msgs::Pose2DStamped& pose, int result_code = OCCUPIEDSTARTEXCEPTION) :
     InvalidStartPoseException(pose, "occupied", result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -228,10 +239,12 @@ public:
 class InvalidGoalPoseException: public GlobalPlannerException
 {
 public:
-  explicit InvalidGoalPoseException(const std::string& description, int result_code = INVALIDGOALPOSEEXCEPTION) : GlobalPlannerException(description, result_code) {}
-  InvalidGoalPoseException(const nav_2d_msgs::Pose2DStamped& pose, const std::string& problem, int result_code = INVALIDGOALPOSEEXCEPTION) :
+  explicit InvalidGoalPoseException(const std::string& description, int result_code = INVALIDGOALPOSEEXCEPTION) :
+    GlobalPlannerException(description, result_code) {}
+  InvalidGoalPoseException(const nav_2d_msgs::Pose2DStamped& pose,
+                          const std::string& problem, int result_code = INVALIDGOALPOSEEXCEPTION) :
     GlobalPlannerException("The goal pose " + poseToString(pose) + " is " + problem, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -241,10 +254,11 @@ public:
 class GoalBoundsException: public InvalidGoalPoseException
 {
 public:
-  explicit GoalBoundsException(const std::string& description, int result_code = GOALBOUNDSEXCEPTION) : InvalidGoalPoseException(description, result_code) {}
+  explicit GoalBoundsException(const std::string& description, int result_code = GOALBOUNDSEXCEPTION) :
+    InvalidGoalPoseException(description, result_code) {}
   explicit GoalBoundsException(const nav_2d_msgs::Pose2DStamped& pose, int result_code = GOALBOUNDSEXCEPTION) :
     InvalidGoalPoseException(pose, "out of bounds", result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -254,10 +268,11 @@ public:
 class OccupiedGoalException: public InvalidGoalPoseException
 {
 public:
-  explicit OccupiedGoalException(const std::string& description, int result_code = OCCUPIEDGOALEXCEPTION) : InvalidGoalPoseException(description, result_code) {}
+  explicit OccupiedGoalException(const std::string& description, int result_code = OCCUPIEDGOALEXCEPTION) :
+    InvalidGoalPoseException(description, result_code) {}
   explicit OccupiedGoalException(const nav_2d_msgs::Pose2DStamped& pose, int result_code = OCCUPIEDGOALEXCEPTION) :
     InvalidGoalPoseException(pose, "occupied", result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -267,9 +282,11 @@ public:
 class NoGlobalPathException: public GlobalPlannerException
 {
 public:
-  explicit NoGlobalPathException(const std::string& description, int result_code = NOGLOBALPATHEXCEPTION) : GlobalPlannerException(description, result_code) {}
-  NoGlobalPathException(int result_code = NOGLOBALPATHEXCEPTION) : GlobalPlannerException("No global path found.", result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  explicit NoGlobalPathException(const std::string& description, int result_code = NOGLOBALPATHEXCEPTION) :
+    GlobalPlannerException(description, result_code) {}
+  NoGlobalPathException(int result_code = NOGLOBALPATHEXCEPTION) :
+    GlobalPlannerException("No global path found.", result_code) {}
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -279,8 +296,9 @@ public:
 class GlobalPlannerTimeoutException: public GlobalPlannerException
 {
 public:
-  explicit GlobalPlannerTimeoutException(const std::string& description, int result_code = GLOBALPLANNERTIMEOUTEXCEPTION) : GlobalPlannerException(description, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  explicit GlobalPlannerTimeoutException(const std::string& description, int result_code = GLOBALPLANNERTIMEOUTEXCEPTION) :
+    GlobalPlannerException(description, result_code) {}
+  virtual int getResultCode() const { return result_code_; }
 };
 
 /**
@@ -290,10 +308,11 @@ public:
 class IllegalTrajectoryException: public LocalPlannerException
 {
 public:
-  IllegalTrajectoryException(const std::string& critic_name, const std::string& description, int result_code = ILLEGALTRAJECTORYEXCEPTION)
+  IllegalTrajectoryException(const std::string& critic_name,
+                            const std::string& description, int result_code = ILLEGALTRAJECTORYEXCEPTION)
     : LocalPlannerException(description, result_code), critic_name_(critic_name) {}
   std::string getCriticName() const { return critic_name_; }
-  virtual int getResultCode() const override { return result_code_; }
+  virtual int getResultCode() const { return result_code_; }
 protected:
   std::string critic_name_;
 };
@@ -305,8 +324,9 @@ protected:
 class NoLegalTrajectoriesException: public LocalPlannerException
 {
 public:
-  explicit NoLegalTrajectoriesException(const std::string& description, int result_code = NOLEGALTRAJECTORIESEXCEPTION) : LocalPlannerException(description, result_code) {}
-  virtual int getResultCode() const override { return result_code_; }
+  explicit NoLegalTrajectoriesException(const std::string& description, int result_code = NOLEGALTRAJECTORIESEXCEPTION) :
+    LocalPlannerException(description, result_code) {}
+  virtual int getResultCode() const { return result_code_; }
 };
 
 }  // namespace nav_core2

--- a/nav_core2/include/nav_core2/exceptions.h
+++ b/nav_core2/include/nav_core2/exceptions.h
@@ -67,7 +67,8 @@
 namespace nav_core2
 {
 
-enum {
+enum 
+{
   COSTMAPEXCEPTION                 =   0,
   COSTMAPSAFETYEXCEPTION           =   1,
   COSTMAPDATALAGEXCEPTION          =   2,
@@ -150,7 +151,6 @@ public:
 
 protected:
     int result_code_;
-
 };
 
 /**
@@ -284,7 +284,7 @@ class NoGlobalPathException: public GlobalPlannerException
 public:
   explicit NoGlobalPathException(const std::string& description, int result_code = NOGLOBALPATHEXCEPTION) :
     GlobalPlannerException(description, result_code) {}
-  NoGlobalPathException(int result_code = NOGLOBALPATHEXCEPTION) :
+  explicit NoGlobalPathException(int result_code = NOGLOBALPATHEXCEPTION) :
     GlobalPlannerException("No global path found.", result_code) {}
   virtual int getResultCode() const { return result_code_; }
 };
@@ -296,7 +296,8 @@ public:
 class GlobalPlannerTimeoutException: public GlobalPlannerException
 {
 public:
-  explicit GlobalPlannerTimeoutException(const std::string& description, int result_code = GLOBALPLANNERTIMEOUTEXCEPTION) :
+  explicit GlobalPlannerTimeoutException(const std::string& description, 
+                                        int result_code = GLOBALPLANNERTIMEOUTEXCEPTION) :
     GlobalPlannerException(description, result_code) {}
   virtual int getResultCode() const { return result_code_; }
 };
@@ -324,7 +325,8 @@ protected:
 class NoLegalTrajectoriesException: public LocalPlannerException
 {
 public:
-  explicit NoLegalTrajectoriesException(const std::string& description, int result_code = NOLEGALTRAJECTORIESEXCEPTION) :
+  explicit NoLegalTrajectoriesException(const std::string& description, 
+                                        int result_code = NOLEGALTRAJECTORIESEXCEPTION) :
     LocalPlannerException(description, result_code) {}
   virtual int getResultCode() const { return result_code_; }
 };


### PR DESCRIPTION
when get the exception code through e.getResultCode() always be the base class's code.

because the "resultcode" is hard coded in the exceptions.h. So i change the result code with Member variables in base class.

And add a set of enumeration constants for exceptions.