### PR TITLE
Add preempt goal functionality to locomove_base

### DIFF
--- a/locomove_base/include/locomove_base/locomove_base.h
+++ b/locomove_base/include/locomove_base/locomove_base.h
@@ -103,6 +103,7 @@ protected:
 
   // MoveBaseAction
   void executeCB();
+  void preemptCB();
   actionlib::SimpleActionServer<move_base_msgs::MoveBaseAction> server_;
 
   // Recoveries

--- a/locomove_base/src/locomove_base.cpp
+++ b/locomove_base/src/locomove_base.cpp
@@ -634,7 +634,7 @@ void LocoMoveBase::preemptCB()
   ROS_INFO("Preempting goal");
   plan_loop_timer_.stop();
   control_loop_timer_.stop();
-  resetState();  
+  resetState();
   server_.setPreempted();
 }
 

--- a/locomove_base/src/locomove_base.cpp
+++ b/locomove_base/src/locomove_base.cpp
@@ -203,6 +203,7 @@ LocoMoveBase::LocoMoveBase(const ros::NodeHandle& nh) :
   goal_sub_ = simple_nh.subscribe<geometry_msgs::PoseStamped>("goal", 1, boost::bind(&LocoMoveBase::goalCB, this, _1));
 
   server_.registerGoalCallback(std::bind(&LocoMoveBase::executeCB, this));
+  server_.registerPreemptCallback(std::bind(&LocoMoveBase::preemptCB, this));
   server_.start();
 
   resetState();
@@ -626,6 +627,15 @@ void LocoMoveBase::executeCB()
 {
   auto move_base_goal = server_.acceptNewGoal();
   setGoal(nav_2d_utils::poseStampedToPose2D(move_base_goal->target_pose));
+}
+
+void LocoMoveBase::preemptCB()
+{
+  ROS_INFO("Preempting goal");
+  plan_loop_timer_.stop();
+  control_loop_timer_.stop();
+  resetState();  
+  server_.setPreempted();
 }
 
 }  // namespace locomove_base


### PR DESCRIPTION
Preempting a goal was not handled yet in `locomove_base`. I've added the bare minimum implementation, suggestions are welcome.