### PR TITLE
[nav_core_adapter] bugfix: resetMap -> resetLayers

### DIFF
--- a/nav_core_adapter/src/costmap_adapter.cpp
+++ b/nav_core_adapter/src/costmap_adapter.cpp
@@ -83,7 +83,7 @@ nav_core2::Costmap::mutex_t* CostmapAdapter::getMutex()
 
 void CostmapAdapter::reset()
 {
-  costmap_->resetMap(0, 0, costmap_->getSizeInCellsX(), costmap_->getSizeInCellsY());
+  costmap_ros_->resetLayers();
 }
 
 void CostmapAdapter::update()


### PR DESCRIPTION
when a user load costmap_2d plugins with nav_core_adapter, 'costmap_2d::Costmap2D::resetMap' does not reset plugins' costmaps. instead, we need to use 'costmap_2d_ros::Costmap2DROS::resetLayers'.

we can mimic the way move_base does:
https://github.com/ros-planning/navigation/blob/melodic-devel/move_base/src/move_base.cpp#L333

implementation of resetLayers:
https://github.com/ros-planning/navigation/blob/melodic-devel/costmap_2d/src/costmap_2d_ros.cpp#L557