### PR TITLE
Fix sum of total cost of different critics

### DIFF
--- a/dwb_local_planner/src/publisher.cpp
+++ b/dwb_local_planner/src/publisher.cpp
@@ -199,7 +199,7 @@ void DWBPublisher::publishCostGrid(const nav_core2::Costmap::Ptr costmap,
     double scale = critic->getScale();
     for (i = 0; i < n; i++)
     {
-      totals.values[i] = cost_grid_pc.channels[channel_index].values[i] * scale;
+      totals.values[i] += cost_grid_pc.channels[channel_index].values[i] * scale;
     }
   }
   cost_grid_pc.channels.push_back(totals);


### PR DESCRIPTION
Only the last cost was visualized instead of the sum of all the costs. A plus sign was missing.