### PR TITLE
More Utility Functions

### DIFF
--- a/nav_2d_utils/CMakeLists.txt
+++ b/nav_2d_utils/CMakeLists.txt
@@ -70,6 +70,9 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(resolution_test test/resolution_test.cpp)
   target_link_libraries(resolution_test path_ops ${catkin_LIBRARIES})
 
+  catkin_add_gtest(bounds_test test/bounds_test.cpp)
+  target_link_libraries(bounds_test bounds ${catkin_LIBRARIES})
+
   add_rostest_gtest(param_tests test/param_tests.launch test/param_tests.cpp)
   target_link_libraries(param_tests polygons ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 endif()

--- a/nav_2d_utils/README.md
+++ b/nav_2d_utils/README.md
@@ -1,6 +1,6 @@
 # nav_2d_utils
 A handful of useful utility functions for nav_core2 packages.
- * Bounds - Utilities for `nav_core2::Bounds` objects interacting with other messages/types
+ * Bounds - Utilities for `nav_core2::Bounds` objects interacting with other messages/types and for dividing a `UIntBounds` into multiple smaller bounds.
  * [Conversions](doc/Conversions.md) - Tools for converting between `nav_2d_msgs` and other types.
  * OdomSubscriber - subscribes to the standard `nav_msgs::Odometry` message and provides access to the velocity component as a `nav_2d_msgs::Twist`
  * Parameters - a couple ROS parameter patterns

--- a/nav_2d_utils/doc/Conversions.md
+++ b/nav_2d_utils/doc/Conversions.md
@@ -44,6 +44,9 @@ Also, `nav_msgs::Path posesToPath(std::vector<geometry_msgs::PoseStamped>)`
 | -- | -- |
 |`nav_grid::NavGridInfo infoToInfo(nav_msgs::MapMetaData, std::string)` | `nav_msgs::MapMetaData infoToInfo(nav_grid::NavGridInfo)`
 
+| to two dimensional pose | to three dimensional pose |
+| -- | -- |
+| `Pose2D getOrigin2D(nav_grid::NavGridInfo)` | `geometry_msgs::Pose getOrigin3D(nav_grid::NavGridInfo)`|
 
 ## Bounds Transformations
 | to `nav_2d_msgs` | from `nav_2d_msgs` |

--- a/nav_2d_utils/include/nav_2d_utils/bounds.h
+++ b/nav_2d_utils/include/nav_2d_utils/bounds.h
@@ -75,6 +75,17 @@ nav_core2::UIntBounds translateBounds(const nav_grid::NavGridInfo& info, const n
  */
 nav_core2::Bounds translateBounds(const nav_grid::NavGridInfo& info, const nav_core2::UIntBounds& bounds);
 
+/**
+ * @brief divide the given bounds up into sub-bounds of roughly equal size
+ * @param original_bounds The original bounds to divide
+ * @param n_cols Positive number of columns to divide the bounds into
+ * @param n_rows Positive number of rows to divide the bounds into
+ * @return vector of a maximum of n_cols*n_rows nonempty bounds
+ * @throws std::invalid_argument when n_cols or n_rows is zero
+ */
+std::vector<nav_core2::UIntBounds> divideBounds(const nav_core2::UIntBounds& original_bounds,
+                                                unsigned int n_cols, unsigned int n_rows);
+
 }  // namespace nav_2d_utils
 
 #endif  // NAV_2D_UTILS_BOUNDS_H

--- a/nav_2d_utils/include/nav_2d_utils/conversions.h
+++ b/nav_2d_utils/include/nav_2d_utils/conversions.h
@@ -93,6 +93,8 @@ nav_2d_msgs::Polygon2DStamped polygon3Dto2D(const geometry_msgs::PolygonStamped&
 // Info Transformations
 nav_2d_msgs::NavGridInfo toMsg(const nav_grid::NavGridInfo& info);
 nav_grid::NavGridInfo fromMsg(const nav_2d_msgs::NavGridInfo& msg);
+geometry_msgs::Pose getOrigin3D(const nav_grid::NavGridInfo& info);
+geometry_msgs::Pose2D getOrigin2D(const nav_grid::NavGridInfo& info);
 nav_grid::NavGridInfo infoToInfo(const nav_msgs::MapMetaData& metadata, const std::string& frame);
 nav_msgs::MapMetaData infoToInfo(const nav_grid::NavGridInfo & info);
 

--- a/nav_2d_utils/src/conversions.cpp
+++ b/nav_2d_utils/src/conversions.cpp
@@ -294,15 +294,30 @@ nav_grid::NavGridInfo infoToInfo(const nav_msgs::MapMetaData& metadata, const st
   return info;
 }
 
+geometry_msgs::Pose getOrigin3D(const nav_grid::NavGridInfo& info)
+{
+  geometry_msgs::Pose origin;
+  origin.position.x = info.origin_x;
+  origin.position.y = info.origin_y;
+  origin.orientation.w = 1.0;
+  return origin;
+}
+
+geometry_msgs::Pose2D getOrigin2D(const nav_grid::NavGridInfo& info)
+{
+  geometry_msgs::Pose2D origin;
+  origin.x = info.origin_x;
+  origin.y = info.origin_y;
+  return origin;
+}
+
 nav_msgs::MapMetaData infoToInfo(const nav_grid::NavGridInfo & info)
 {
   nav_msgs::MapMetaData metadata;
   metadata.resolution = info.resolution;
   metadata.width = info.width;
   metadata.height = info.height;
-  metadata.origin.position.x = info.origin_x;
-  metadata.origin.position.y = info.origin_y;
-  metadata.origin.orientation.w = 1.0;
+  metadata.origin = getOrigin3D(info);
   return metadata;
 }
 

--- a/nav_2d_utils/test/bounds_test.cpp
+++ b/nav_2d_utils/test/bounds_test.cpp
@@ -1,0 +1,199 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <gtest/gtest.h>
+#include <nav_2d_utils/bounds.h>
+#include <nav_grid/vector_nav_grid.h>
+#include <vector>
+
+using nav_2d_utils::divideBounds;
+using nav_core2::UIntBounds;
+
+/**
+ * @brief Count the values in a grid.
+ * @param[in] The grid
+ * @param[out] match Number of values == 1
+ * @param[out] missed Number of values == 0
+ * @param[out] multiple Number of other values
+ */
+void countValues(const nav_grid::VectorNavGrid<unsigned char>& grid,
+                 unsigned int& match, unsigned int& missed, unsigned int& multiple)
+{
+  match = 0;
+  missed = 0;
+  multiple = 0;
+
+  nav_grid::NavGridInfo info = grid.getInfo();
+
+  // No iterator to avoid tricky depenencies
+  for (unsigned int x = 0; x < info.width; x++)
+  {
+    for (unsigned int y = 0; y < info.height; y++)
+    {
+      switch (grid(x, y))
+      {
+      case 0:
+        missed++;
+        break;
+      case 1:
+        match++;
+        break;
+      default:
+        multiple++;
+        break;
+      }
+    }
+  }
+}
+
+TEST(DivideBounds, zeroes)
+{
+  UIntBounds bounds(2, 2, 5, 5);
+  // Number of rows/cols has to be positive
+  EXPECT_THROW(divideBounds(bounds, 0, 2), std::invalid_argument);
+  EXPECT_THROW(divideBounds(bounds, 2, 0), std::invalid_argument);
+  EXPECT_THROW(divideBounds(bounds, 0, 0), std::invalid_argument);
+  EXPECT_NO_THROW(divideBounds(bounds, 2, 2));
+
+  bounds.reset();
+  // check for errors with empty bounds
+  EXPECT_NO_THROW(divideBounds(bounds, 2, 2));
+}
+
+/**
+ * This test is for the divideBounds method and takes grids of various sizes
+ * (cycled through with the outer two loops) and tries to divide them into subgrids of
+ * various sizes (cycled through with the next two loops). The resulting vector of
+ * bounds should cover every cell in the original grid, so each of the divided bounds is
+ * iterated over, adding one to each grid cell. If everything works perfectly, each cell
+ * should be touched exactly once.
+ */
+TEST(DivideBounds, iterative_tests)
+{
+  nav_grid::VectorNavGrid<unsigned char> full_grid;
+  nav_grid::NavGridInfo info;
+
+  // count variables
+  unsigned int match, missed, multiple;
+
+  for (info.width = 1; info.width < 15; info.width++)
+  {
+    for (info.height = 1; info.height < 15; info.height++)
+    {
+      full_grid.setInfo(info);
+      UIntBounds full_bounds = nav_2d_utils::getFullUIntBounds(info);
+      for (unsigned int rows = 1; rows < 11u; rows++)
+      {
+        for (unsigned int cols = 1; cols < 11u; cols++)
+        {
+          full_grid.reset();
+          std::vector<UIntBounds> divided = divideBounds(full_bounds, cols, rows);
+          ASSERT_LE(divided.size(), rows * cols) << info.width << "x" << info.height << " " << rows << "x" << cols;
+          for (const UIntBounds& sub : divided)
+          {
+            EXPECT_FALSE(sub.isEmpty());
+            // Can't use nav_grid_iterator for circular dependencies
+            for (unsigned int x = sub.getMinX(); x <= sub.getMaxX(); x++)
+            {
+              for (unsigned int y = sub.getMinY(); y <= sub.getMaxY(); y++)
+              {
+                full_grid.setValue(x, y, full_grid(x, y) + 1);
+              }
+            }
+          }
+
+          countValues(full_grid, match, missed, multiple);
+          ASSERT_EQ(match, info.width * info.height) << "Full grid: " << info.width << "x" << info.height
+                                                     << "  Requested divisions: " << rows << "x" << cols;
+          EXPECT_EQ(missed, 0u);
+          EXPECT_EQ(multiple, 0u);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * This test is for the divideBounds method and calls it recursively to
+ * ensure that the method works when the minimum values in the original bounds
+ * are not zero.
+ */
+TEST(DivideBounds, recursive_tests)
+{
+  nav_grid::VectorNavGrid<unsigned char> full_grid;
+  nav_grid::NavGridInfo info;
+  info.width = 100;
+  info.height = 100;
+  full_grid.setInfo(info);
+
+  UIntBounds full_bounds = nav_2d_utils::getFullUIntBounds(info);
+
+  std::vector<UIntBounds> level_one = divideBounds(full_bounds, 2, 2);
+  ASSERT_EQ(level_one.size(), 4u);
+  for (const UIntBounds& sub : level_one)
+  {
+    std::vector<UIntBounds> level_two = divideBounds(sub, 2, 2);
+    ASSERT_EQ(level_two.size(), 4u);
+    for (const UIntBounds& subsub : level_two)
+    {
+      EXPECT_GE(subsub.getMinX(), sub.getMinX());
+      EXPECT_LE(subsub.getMaxX(), sub.getMaxX());
+      EXPECT_GE(subsub.getMinY(), sub.getMinY());
+      EXPECT_LE(subsub.getMaxY(), sub.getMaxY());
+      // Can't use nav_grid_iterator for circular dependencies
+      for (unsigned int x = subsub.getMinX(); x <= subsub.getMaxX(); x++)
+      {
+        for (unsigned int y = subsub.getMinY(); y <= subsub.getMaxY(); y++)
+        {
+          full_grid.setValue(x, y, full_grid(x, y) + 1);
+        }
+      }
+    }
+  }
+
+  // Count values
+  unsigned int match = 0,
+               missed = 0,
+               multiple = 0;
+  countValues(full_grid, match, missed, multiple);
+  ASSERT_EQ(match, info.width * info.height);
+  EXPECT_EQ(missed, 0u);
+  EXPECT_EQ(multiple, 0u);
+}
+
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/nav_core2/include/nav_core2/bounds.h
+++ b/nav_core2/include/nav_core2/bounds.h
@@ -42,6 +42,19 @@
 namespace nav_core2
 {
 /**
+ * @brief Templatized method for checking if a value falls inside a one-dimensional range
+ * @param value     The value to check
+ * @param min_value The minimum value of the range
+ * @param max_value The maximum value of the range
+ * @return True if the value is within the range
+ */
+template <typename NumericType>
+inline bool inRange(const NumericType value, const NumericType min_value, const NumericType max_value)
+{
+  return min_value <= value && value <= max_value;
+}
+
+/**
  * @class GenericBounds
  * @brief Templatized class that represents a two dimensional bounds with ranges [min_x, max_x] [min_y, max_y] inclusive
  */
@@ -120,6 +133,38 @@ public:
   }
 
   /**
+   * @brief Returns true if the point is inside this range
+   */
+  bool contains(NumericType x, NumericType y) const
+  {
+    return inRange(x, min_x_, max_x_) && inRange(y, min_y_, max_y_);
+  }
+
+  /**
+   * @brief returns true if the two bounds overlap each other
+   */
+  bool overlaps(const GenericBounds<NumericType>& other) const
+  {
+    return !isEmpty() && !other.isEmpty()
+             && max_y_ >= other.min_y_ && min_y_ <= other.max_y_
+             && max_x_ >= other.min_x_ && min_x_ <= other.max_x_;
+  }
+
+  /**
+   * @brief comparison operator that requires all fields are equal
+   */
+  bool operator==(const GenericBounds<NumericType>& other) const
+  {
+    return min_x_ == other.min_x_ && min_y_ == other.min_y_ &&
+           max_x_ == other.max_x_ && max_y_ == other.max_y_;
+  }
+
+  bool operator!=(const GenericBounds<NumericType>& other) const
+  {
+    return !operator==(other);
+  }
+
+  /**
    * @brief Returns a string representation of the bounds
    */
   std::string toString() const
@@ -146,12 +191,17 @@ protected:
 
 using Bounds = GenericBounds<double>;
 
+inline unsigned int getDimension(unsigned int min_v, unsigned int max_v)
+{
+  return (min_v > max_v) ? 0 : max_v - min_v + 1;
+}
+
 class UIntBounds : public GenericBounds<unsigned int>
 {
 public:
   using GenericBounds<unsigned int>::GenericBounds;
-  unsigned int getWidth() const { return max_x_ - min_x_ + 1; }
-  unsigned int getHeight() const { return max_y_ - min_y_ + 1; }
+  unsigned int getWidth() const { return getDimension(min_x_, max_x_); }
+  unsigned int getHeight() const { return getDimension(min_y_, max_y_); }
 };
 
 }  // namespace nav_core2

--- a/nav_core2/test/bounds_test.cpp
+++ b/nav_core2/test/bounds_test.cpp
@@ -35,6 +35,7 @@
 #include <nav_core2/bounds.h>
 
 using nav_core2::Bounds;
+using nav_core2::UIntBounds;
 
 TEST(Bounds, test_bounds_simple)
 {
@@ -47,6 +48,9 @@ TEST(Bounds, test_bounds_simple)
   EXPECT_EQ(5.0, b.getMaxX());
   EXPECT_EQ(6.0, b.getMinY());
   EXPECT_EQ(6.0, b.getMaxY());
+  EXPECT_TRUE(b.contains(5.0, 6.0));
+  EXPECT_FALSE(b.contains(5.5, 6.0));
+  EXPECT_FALSE(b.contains(5.5, 4.0));
   EXPECT_FALSE(b.isEmpty());
 
   Bounds b2 = b;
@@ -60,7 +64,57 @@ TEST(Bounds, test_bounds_simple)
   EXPECT_EQ(5.0, b2.getMaxX());
   EXPECT_EQ(6.0, b2.getMinY());
   EXPECT_EQ(6.0, b2.getMaxY());
+  EXPECT_FALSE(b.contains(5.0, 6.0));
+  EXPECT_FALSE(b.contains(5.5, 6.0));
+  EXPECT_TRUE(b2.contains(5.0, 6.0));
+  EXPECT_FALSE(b.contains(5.5, 6.0));
   EXPECT_TRUE(b.isEmpty());
+
+  Bounds b3;
+  b3.touch(1.0, 5.0);
+  b3.touch(4.0, 2.0);
+  EXPECT_TRUE(b3.contains(3.0, 3.0));
+  EXPECT_FALSE(b3.contains(0.0, 3.0));
+  EXPECT_FALSE(b3.contains(5.0, 3.0));
+  EXPECT_FALSE(b3.contains(3.0, 6.0));
+  EXPECT_FALSE(b3.contains(3.0, 1.0));
+}
+
+TEST(Bounds, test_dimensions)
+{
+  UIntBounds empty;
+  UIntBounds square(0, 0, 5, 5);
+  UIntBounds rectangle(1, 4, 3, 15);
+  EXPECT_EQ(empty.getWidth(), 0u);
+  EXPECT_EQ(empty.getHeight(), 0u);
+
+  EXPECT_EQ(square.getWidth(), 6u);
+  EXPECT_EQ(square.getHeight(), 6u);
+
+  EXPECT_EQ(rectangle.getWidth(), 3u);
+  EXPECT_EQ(rectangle.getHeight(), 12u);
+}
+
+TEST(Bounds, test_bounds_overlap)
+{
+  UIntBounds b0(0, 0, 5, 5);
+  UIntBounds b1(0, 0, 5, 5);
+  UIntBounds b2(0, 0, 3, 3);
+  UIntBounds b3(3, 0, 4, 4);
+  UIntBounds b4(4, 0, 4, 4);
+  UIntBounds b5(1, 4, 3, 15);
+  UIntBounds b6(10, 10, 10, 10);
+  EXPECT_TRUE(b0.overlaps(b0));
+  EXPECT_TRUE(b0.overlaps(b1));
+  EXPECT_TRUE(b0.overlaps(b2));
+  EXPECT_TRUE(b2.overlaps(b0));
+  EXPECT_TRUE(b0.overlaps(b3));
+  EXPECT_TRUE(b2.overlaps(b3));
+  EXPECT_FALSE(b2.overlaps(b4));
+  EXPECT_TRUE(b0.overlaps(b5));
+  EXPECT_TRUE(b5.overlaps(b0));
+  EXPECT_FALSE(b0.overlaps(b6));
+  EXPECT_FALSE(b6.overlaps(b0));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
 * `getOrigin` function for `NavGridInfo` objects that return a pose for where the origin of the grid is.  
 * Additional helpful methods for `nav_core2::Bounds` objects including 
    * `contains(x, y)`
    * `overlaps(Bounds)`
    * `==` and `!=` operators
 * Fix bug with empty `UIntBounds`
 * Utility method for converting `UIntBounds` into multiple smaller `UIntBounds` covering the same area. 