### PR TITLE
Changing cost type for calculateKernel

### DIFF
--- a/dlux_global_planner/include/dlux_global_planner/kernel_function.h
+++ b/dlux_global_planner/include/dlux_global_planner/kernel_function.h
@@ -80,7 +80,7 @@ inline bool operator &(CardinalDirection a, CardinalDirection b)
  * @param upstream[out] Direction of cells used in computation (if not null initially)
  * @return potential for this cell
  */
-static float calculateKernel(const PotentialGrid& potential_grid, unsigned char cost, unsigned int x, unsigned int y,
+static float calculateKernel(const PotentialGrid& potential_grid, float cost, unsigned int x, unsigned int y,
                              CardinalDirection* upstream = nullptr)
 {
   // See README.md for more about this calculation


### PR DESCRIPTION
The cost values that get passed to `calculateKernel` are not guaranteed to be `unsigned char`s, and therefore can't be guaranteed to be in the range of an `unsigned char`. This can lead to overflowing the `cost` variable, which will obviously lead to incorrect kernel computation.